### PR TITLE
added version check and branch for BWN_DISASMS

### DIFF
--- a/findyara.py
+++ b/findyara.py
@@ -37,6 +37,14 @@ PLUGIN_NAME = "FindYara"
 PLUGIN_HOTKEY = "Ctrl-Alt-Y"
 VERSION = '3.3.0'
 
+major, minor = map(int, idaapi.get_kernel_version().split("."))
+
+IDA_9 = major >= 9
+if IDA_9:
+    BWN_DISASM = ida_kernwin.BWN_DISASM
+else:
+    BWN_DISASM = idaapi.BWN_DISASMS
+
 try:
     class Kp_Menu_Context(idaapi.action_handler_t):
         def __init__(self):
@@ -81,7 +89,7 @@ try:
 
         @classmethod
         def update(self, ctx):
-            if ctx.form_type == idaapi.BWN_DISASM:
+            if ctx.widget_type == BWN_DISASM:
                 return idaapi.AST_ENABLE_FOR_WIDGET
             return idaapi.AST_DISABLE_FOR_WIDGET
 


### PR DESCRIPTION
`idaapi.BWN_DISASMS` is moved to `ida_kernwin.BWN_DISASM`
https://python.docs.hex-rays.com/ida_kernwin#bwn_disasms

_Note: for `ida_kernwin.BWN_DISASM` there is no `S` at the end as in the current working version, both have the same value `ida_kernwin.BWN_DISASM` according to the [documentation](https://python.docs.hex-rays.com/ida_kernwin#bwn_disasm), however if you try to access `ida_kernwin.BWN_DISASMS` in IDA v9.0 it does not exists._
> BWN_DISASM
> 
> ```
> BWN_DISASM = 27
> ```
> 
> BWN_DISASMS
> 
> ```
> BWN_DISASMS = 27
> ```
source: https://python.docs.hex-rays.com/ida_kernwin#bwn_disasm

to address this i've added a global constant where the value is set based on the version